### PR TITLE
3-create-dockerfile-and-docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:17-jdk AS BUILDER
+WORKDIR layering
+ARG JAR=build/libs/open-erp-accounting-*.jar
+COPY ${JAR} app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR application
+COPY --from=BUILDER layering/dependencies/ ./
+COPY --from=BUILDER layering/spring-boot-loader/ ./
+COPY --from=BUILDER layering/snapshot-dependencies/ ./
+COPY --from=BUILDER layering/application/ ./
+ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    // Implementations
     implementation("ch.qos.logback:logback-classic:1.4.11")
     implementation("ch.qos.logback:logback-core:1.4.11")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -34,6 +35,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.postgresql:postgresql:42.6.0")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+    // Development
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 
     // Testing
     testImplementation("io.rest-assured:rest-assured:5.3.1")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:15.4
+    ports:
+      - "5432:5432"
+    restart: always
+    profiles:
+      - dev
+      - local
+    environment:
+      POSTGRES_USER: open-erp
+      POSTGRES_DB: open-erp
+      POSTGRES_PASSWORD: open-erp-testing
+  open-erp-accounting:
+    depends_on:
+      - db
+    image: open-erp-accounting:latest
+    build:
+      context: .
+    ports:
+      - "8080:8080"
+    profiles:
+      - local

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,6 +1,10 @@
 spring:
   datasource:
-    # Replace all of these with the docker container configuration when we get to that point
-    url: jdbc:tc:postgresql:15.4:///openerp
-    username: postgres
-    password: postgres
+    url: jdbc:postgresql://db:5432/open-erp
+    username: open-erp
+    password: open-erp-testing
+  docker:
+    compose:
+      enabled: true
+      profiles:
+        active: dev

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+logging:
+  level:
+    com.zaxxer.hikari: WARN
+    org.springframework: WARN
 management:
   endpoints:
     enabled-by-default: false


### PR DESCRIPTION
- `Dockerfile` that creates a layered Docker image from the application's fat JAR
- `docker-compose` with profiles so that the DB service can be run separately by Spring Boot
- `spring-boot-docker-compose` added to spin up the DB service whenever running in the `dev` profile