### PR TITLE
added delete endpoint and delete links to get entry object responses

### DIFF
--- a/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerController.kt
+++ b/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerController.kt
@@ -74,4 +74,15 @@ class LedgerController(
             .status(HttpStatus.OK)
             .body(entries)
     }
+
+    @DeleteMapping("/{id}")
+    fun deleteLedgerEntryById(@PathVariable id: UUID): ResponseEntity<Any> {
+        log.debug("processing delete entry request for entry {}", id)
+
+        ledgerService.deleteLedgerEntryById(id)
+
+        return ResponseEntity
+            .noContent()
+            .build()
+    }
 }

--- a/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerModelAssembler.kt
+++ b/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerModelAssembler.kt
@@ -12,7 +12,8 @@ class LedgerModelAssembler : RepresentationModelAssembler<Ledger, EntityModel<Le
     override fun toModel(entity: Ledger): EntityModel<Ledger> {
         return EntityModel.of(
             entity,
-            linkTo<LedgerController> { getLedgerEntryById(entity.ledgerId) }.withSelfRel()
+            linkTo<LedgerController> { getLedgerEntryById(entity.ledgerId) }.withSelfRel(),
+            linkTo<LedgerController> { deleteLedgerEntryById(entity.ledgerId) }.withRel("delete")
         )
     }
 }

--- a/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/service/LedgerService.kt
+++ b/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/service/LedgerService.kt
@@ -102,4 +102,13 @@ class LedgerService(
 
         return pagedResourcesAssembler.toModel(entries, ledgerModelAssembler)
     }
+
+    fun deleteLedgerEntryById(id: UUID) {
+        if (ledgerRepository.existsById(id)) {
+            ledgerRepository.deleteById(id)
+            log.debug("successfully deleted ledger entry {}", id)
+        } else {
+            log.debug("ledger entry {} does not exist", id)
+        }
+    }
 }

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerDeleteByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerDeleteByIdFT.kt
@@ -11,15 +11,13 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import io.restassured.path.json.JsonPath
 import org.apache.http.HttpStatus
-import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.util.*
 
-class LedgerGetByIdFT : AbstractBaseFT() {
+class LedgerDeleteByIdFT : AbstractBaseFT() {
 
     @Autowired
     private lateinit var ledgerRepository: LedgerRepository
@@ -54,47 +52,22 @@ class LedgerGetByIdFT : AbstractBaseFT() {
     }
 
     @Test
-    fun `can get an entry by its id`() {
-        val response = Given {
-            accept(ContentType.JSON)
-        } When {
-            get(entry.getString("_links.self.href")) // get by the self reference link returned in the response
+    fun `can delete an existing entry by its ID and get back a 204`() {
+        When {
+            delete(entry.getString("_links.delete.href"))
         } Then {
-            statusCode(HttpStatus.SC_OK)
-            body("ledgerId", equalTo(entry.getString("ledgerId")))
-            body("title", equalTo(entry.getString("title")))
-            body("_links.self.href", equalTo(entry.getString("_links.self.href")))
-            body("_links.delete.href", equalTo(entry.getString("_links.delete.href")))
-        } Extract {
-            body()
-            jsonPath()
+            statusCode(HttpStatus.SC_NO_CONTENT)
         }
-
-        // Definitely should double-check the tags on individual gets
-        assertThat(
-            response.getList<String>("tags").containsAll(entry.getList("tags"))
-        ).isTrue()
     }
 
     @Test
-    fun `attempting to get an event with an invalid id returns 404`() {
+    fun `deleting an entry that does not exist still returns a 204`() {
         Given {
             pathParam("id", UUID.randomUUID())
         } When {
-            get("/ledger/{id}")
+            delete("/ledger/{id}")
         } Then {
-            statusCode(HttpStatus.SC_NOT_FOUND)
-        }
-    }
-
-    @Test
-    fun `id param that is anything but a UUID returns a 400`() {
-        Given {
-            pathParam("id", "I'm a string, not UUID")
-        } When {
-            get("/ledger/{id}")
-        } Then {
-            statusCode(HttpStatus.SC_BAD_REQUEST)
+            statusCode(HttpStatus.SC_NO_CONTENT)
         }
     }
 }

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPostFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPostFT.kt
@@ -3,7 +3,6 @@ package com.github.andrewchaney.openerpaccounting.ledger
 import com.github.andrewchaney.openerpaccounting.AbstractBaseFT
 import com.github.andrewchaney.openerpaccounting.ledger.model.EntryType
 import com.github.andrewchaney.openerpaccounting.ledger.view.LedgerRepository
-import com.github.andrewchaney.openerpaccounting.ledger.view.TagRepository
 import com.github.andrewchaney.openerpaccounting.ledger.wire.LedgerEntryRequest
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.restassured.http.ContentType
@@ -24,8 +23,7 @@ class LedgerPostFT : AbstractBaseFT() {
     @Autowired
     private lateinit var ledgerRepository: LedgerRepository
 
-    @Autowired
-    private lateinit var tagRepository: TagRepository
+    private val validator = UrlValidator(UrlValidator.ALLOW_LOCAL_URLS)
 
     @BeforeEach
     fun reset() {
@@ -68,9 +66,8 @@ class LedgerPostFT : AbstractBaseFT() {
             jsonPath()
         }
 
-        assertThat(
-            UrlValidator(UrlValidator.ALLOW_LOCAL_URLS).isValid(response.getString("_links.self.href"))
-        ).isTrue()
+        assertThat(validator.isValid(response.getString("_links.self.href"))).isTrue()
+        assertThat(validator.isValid(response.getString("_links.delete.href"))).isTrue()
     }
 
     @Test


### PR DESCRIPTION
- Added `DELETE:/ledger/{id}` endpoint
- Added HAL link to delete endpoint on entry objects in `GET` responses
- Associated FTs