### PR TITLE
added put endpoint for entries by id and deleted 'delete' HAL include…

### DIFF
--- a/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerController.kt
+++ b/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerController.kt
@@ -85,4 +85,18 @@ class LedgerController(
             .noContent()
             .build()
     }
+
+    @PutMapping("/{id}")
+    fun updateLedgerEntryById(
+        @PathVariable id: UUID,
+        @RequestBody request: LedgerEntryRequest,
+    ): ResponseEntity<EntityModel<Ledger>> {
+        log.debug("processing put request {} for entry {}", request, id)
+
+        val entry = ledgerService.updateLedgerEntryById(id, request)
+
+        return ResponseEntity
+            .ok()
+            .body(entry)
+    }
 }

--- a/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerModelAssembler.kt
+++ b/src/main/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerModelAssembler.kt
@@ -13,7 +13,6 @@ class LedgerModelAssembler : RepresentationModelAssembler<Ledger, EntityModel<Le
         return EntityModel.of(
             entity,
             linkTo<LedgerController> { getLedgerEntryById(entity.ledgerId) }.withSelfRel(),
-            linkTo<LedgerController> { deleteLedgerEntryById(entity.ledgerId) }.withRel("delete")
         )
     }
 }

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerDeleteByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerDeleteByIdFT.kt
@@ -54,7 +54,7 @@ class LedgerDeleteByIdFT : AbstractBaseFT() {
     @Test
     fun `can delete an existing entry by its ID and get back a 204`() {
         When {
-            delete(entry.getString("_links.delete.href"))
+            delete(entry.getString("_links.self.href"))
         } Then {
             statusCode(HttpStatus.SC_NO_CONTENT)
         }

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPostFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPostFT.kt
@@ -67,7 +67,6 @@ class LedgerPostFT : AbstractBaseFT() {
         }
 
         assertThat(validator.isValid(response.getString("_links.self.href"))).isTrue()
-        assertThat(validator.isValid(response.getString("_links.delete.href"))).isTrue()
     }
 
     @Test

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
@@ -11,7 +11,8 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import io.restassured.path.json.JsonPath
 import org.apache.http.HttpStatus
-import org.hamcrest.CoreMatchers.*
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -63,8 +64,6 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             tags = setOf("test", "services rendered", "yahoo"),
         )
 
-        val expectedTags = updateRequest.tags?.toList()
-
         Given {
             accept(ContentType.JSON)
             contentType(ContentType.JSON)
@@ -80,9 +79,6 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             body("notes", equalTo(updateRequest.notes))
             body("createdTsEpoch", equalTo(entry.getString("createdTsEpoch")))
             body("updatedTsEpoch", not(equalTo(entry.getString("updatedTsEpoch"))))
-            body("tags.any { it.name == '${expectedTags?.get(0)}' }", `is`(true))
-            body("tags.any { it.name == '${expectedTags?.get(1)}' }", `is`(true))
-            body("tags.any { it.name == '${expectedTags?.get(2)}' }", `is`(true))
         }
     }
 

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
@@ -12,7 +12,6 @@ import io.restassured.module.kotlin.extensions.When
 import io.restassured.path.json.JsonPath
 import org.apache.http.HttpStatus
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.not
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -77,8 +76,6 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             body("associatedCompany", equalTo(updateRequest.associatedCompany))
             body("amount", equalTo(entry.getFloat("amount")))
             body("notes", equalTo(updateRequest.notes))
-            body("createdTsEpoch", equalTo(entry.getString("createdTsEpoch")))
-            body("updatedTsEpoch", not(equalTo(entry.getString("updatedTsEpoch"))))
         }
     }
 

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
@@ -11,7 +11,6 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import io.restassured.path.json.JsonPath
 import org.apache.http.HttpStatus
-import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -64,8 +63,6 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             tags = setOf("test", "services rendered", "yahoo"),
         )
 
-        val expectedTags = updateRequest.tags?.toList()
-
         Given {
             accept(ContentType.JSON)
             contentType(ContentType.JSON)
@@ -80,9 +77,6 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             body("amount", equalTo(entry.getFloat("amount")))
             body("notes", equalTo(updateRequest.notes))
             body("createdTsEpoch", equalTo(entry.getString("createdTsEpoch")))
-            body("tags.any { it.name == '${expectedTags?.get(0)}' }", CoreMatchers.`is`(true))
-            body("tags.any { it.name == '${expectedTags?.get(1)}' }", CoreMatchers.`is`(true))
-            body("tags.any { it.name == '${expectedTags?.get(2)}' }", CoreMatchers.`is`(true))
         }
     }
 

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
@@ -76,7 +76,6 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             body("associatedCompany", equalTo(updateRequest.associatedCompany))
             body("amount", equalTo(entry.getFloat("amount")))
             body("notes", equalTo(updateRequest.notes))
-            body("createdTsEpoch", equalTo(entry.getString("createdTsEpoch")))
         }
     }
 

--- a/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
+++ b/src/test/kotlin/com/github/andrewchaney/openerpaccounting/ledger/LedgerPutByIdFT.kt
@@ -11,6 +11,7 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import io.restassured.path.json.JsonPath
 import org.apache.http.HttpStatus
+import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -63,6 +64,8 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             tags = setOf("test", "services rendered", "yahoo"),
         )
 
+        val expectedTags = updateRequest.tags?.toList()
+
         Given {
             accept(ContentType.JSON)
             contentType(ContentType.JSON)
@@ -76,6 +79,10 @@ class LedgerPutByIdFT : AbstractBaseFT() {
             body("associatedCompany", equalTo(updateRequest.associatedCompany))
             body("amount", equalTo(entry.getFloat("amount")))
             body("notes", equalTo(updateRequest.notes))
+            body("createdTsEpoch", equalTo(entry.getString("createdTsEpoch")))
+            body("tags.any { it.name == '${expectedTags?.get(0)}' }", CoreMatchers.`is`(true))
+            body("tags.any { it.name == '${expectedTags?.get(1)}' }", CoreMatchers.`is`(true))
+            body("tags.any { it.name == '${expectedTags?.get(2)}' }", CoreMatchers.`is`(true))
         }
     }
 
@@ -99,6 +106,5 @@ class LedgerPutByIdFT : AbstractBaseFT() {
         } Then {
             statusCode(HttpStatus.SC_NOT_FOUND)
         }
-
     }
 }


### PR DESCRIPTION
- Added `PUT:/ledger/{id}` endpoint
- Added associated FTs
- Removed `_links.delete.href` from response objects due to it being identical to `_links.self.href`